### PR TITLE
Add tool.poetry.scripts to provide an executable

### DIFF
--- a/databusclient/__init__.py
+++ b/databusclient/__init__.py
@@ -1,5 +1,7 @@
 from databusclient import cli
 from databusclient.client import create_dataset, deploy, create_distribution
 
+__all__ = ["create_dataset", "deploy", "create_distribution"]
+
 def run():
     cli.app()

--- a/databusclient/__init__.py
+++ b/databusclient/__init__.py
@@ -1,1 +1,5 @@
+from databusclient import cli
 from databusclient.client import create_dataset, deploy, create_distribution
+
+def run():
+    cli.app()

--- a/databusclient/cli.py
+++ b/databusclient/cli.py
@@ -36,4 +36,4 @@ def deploy(
 
 @app.command()
 def download(collection: str):
-    typer.echo(f"TODO")
+    typer.echo("TODO")

--- a/databusclient/client.py
+++ b/databusclient/client.py
@@ -3,7 +3,6 @@ from typing import List, Dict, Tuple, Optional, Union
 import requests
 import hashlib
 import json
-from urllib.parse import urldefrag
 
 __debug = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ black = "^22.6.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"
 
+[tool.poetry.scripts]
+databusclient = "databusclient:run"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This change allows to install the databusclient with pipx.

```
$ pipx install git+https://github.com/white-gecko/databus-python-client.git@feature/addExecutable
  installed package databusclient 0.12, installed using Python 3.12.0
  These apps are now globally available
    - databusclient
done! ✨ 🌟 ✨

$ databusclient --help
Usage: databusclient [OPTIONS] COMMAND [ARGS]...

Options:
  --install-completion [bash|zsh|fish|powershell|pwsh]
                                  Install completion for the specified shell.
  --show-completion [bash|zsh|fish|powershell|pwsh]
                                  Show completion for the specified shell, to
                                  copy it or customize the installation.
  --help                          Show this message and exit.

Commands:
  deploy
  download
```