### PR TITLE
test: Verify fix for Issue #24 with regression test

### DIFF
--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -38,6 +38,11 @@ def test_get_content_variants():
     with pytest.raises(BadArgumentException):
         _ = _get_content_variants("https://example.com/file.ttl|invalidformat")
 
+    # Regression test for Issue #24: verify that providing a URL without variants 
+    # returns an empty dict instead of crashing with IndexError.
+    cvs = _get_content_variants("https://data.openflaas.de/milandoj/group-1/artifact-1/version-1/file.txt.bz2")
+    assert cvs == {}
+
 
 # @pytest.mark.skip(reason="temporarily disabled since code needs fixing")
 def test_distribution_cases():


### PR DESCRIPTION
# Pull Request

## Description

I investigated Issue #24 ("deploy related -> content variant issue") where a specific URL format was reported to cause an `IndexError`.

I attempted to reproduce the crash using the current `main` branch, but the issue appears to be already resolved (likely by the existing safety check `if len(args) < 2`).

To ensure this remains fixed and to close the issue, I have added a regression test case in `tests/test_deploy.py` that uses the exact input reported in the issue.

**Changes:**
Added unit test case to `test_get_content_variants` verifying that a URL without variant segments returns `{}` instead of crashing.

**Related Issues**
Resolves #24.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [x] Housekeeping

## Checklist:
- [x] My code follows the [ruff code style](http://stellarium.org/doc/head/codingStyle.html) of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
    - [x] `poetry run pytest` - all tests passed
    - [ ] `poetry run ruff check` - no linting errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of URLs without content variants that previously caused errors.

* **Tests**
  * Added regression tests for deployment scenarios.
  * Updated test expectations to align with current deployment payload structures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->