### PR TITLE
fix(download): use setMethod('POST') for SPARQL wrapper

### DIFF
--- a/databusclient/api/download.py
+++ b/databusclient/api/download.py
@@ -590,7 +590,7 @@ def _query_sparql_endpoint(endpoint_url, query, databus_key=None) -> dict:
         Dictionary containing the query results.
     """
     sparql = SPARQLWrapper(endpoint_url)
-    sparql.method = "POST"
+    sparql.setMethod("POST")
     sparql.setQuery(query)
     sparql.setReturnFormat(JSON)
     if databus_key is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ if "SPARQLWrapper" not in sys.modules:
         def __init__(self, *args, **kwargs):
             pass
 
+        def setMethod(self, method):
+            self._method = method
+
         def setQuery(self, q):
             self._q = q
 


### PR DESCRIPTION
Resolves #69 

Using direct attribute assignment on `SPARQLWrapper` (`sparql.method = 'POST'`) is silently ignored by the wrapper, which defaults to GET. Large SPARQL queries (e.g. from collection endpoints) then exceed GET URL-length limits. 

This PR uses the correct `setMethod('POST')` API, and updates the `DummySPARQL` test stub to mock the method appropriately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how POST-based SPARQL queries are configured, helping download requests work more reliably.
  * Updated test support for the SPARQL client so local test runs remain compatible when the external library is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->