### PR TITLE
fix(download): use numeric sort key for artifact version URLs

### DIFF
--- a/databusclient/api/download.py
+++ b/databusclient/api/download.py
@@ -844,6 +844,18 @@ def _download_artifact(
         )
 
 
+def _parse_version_key(url: str) -> tuple:
+    """Return a numeric sort key derived from the version segment of a Databus URL.
+
+    Splits the trailing version segment by non-digit characters and compares each
+    part as an integer, so '2.10.0' correctly sorts after '2.9.0' (unlike plain
+    lexicographic sort where '2.9' > '2.10' as strings).
+    """
+    segment = url.rstrip("/").split("/")[-1]
+    parts = re.split(r"[^0-9]+", segment)
+    return tuple(int(p) for p in parts if p.isdigit())
+
+
 def _get_databus_versions_of_artifact(
     json_str: str, all_versions: bool
 ) -> str | List[str]:
@@ -875,7 +887,7 @@ def _get_databus_versions_of_artifact(
     if not version_urls:
         raise ValueError("No versions found in artifact JSON-LD")
 
-    version_urls.sort(reverse=True)  # Sort versions in descending order
+    version_urls.sort(key=_parse_version_key, reverse=True)
 
     if all_versions:
         return version_urls


### PR DESCRIPTION
Resolves #70 

`version_urls.sort(reverse=True)` performs a plain lexicographic sort, which returns the wrong 'latest' version for semver-style IDs (e.g. `2.10.0` sorts before `2.9.0` as strings, making `2.9.0` the 'latest').

This PR adds a `_parse_version_key()` helper that splits the trailing URL segment on non-digit characters and compares each part as an integer, yielding correct numeric ordering. Date-style versions (e.g. 2022.12.01) continue to work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected artifact version selection to sort versions numerically in descending order.
  * Ensures versions such as `2.10.0` are correctly recognized as newer than `2.9.0`.
  * Improved handling of date-based, calendar, numeric, and prefixed semantic versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->