### PR TITLE
feat(cli): add --version flag to command line interface

### DIFF
--- a/databusclient/__init__.py
+++ b/databusclient/__init__.py
@@ -5,10 +5,11 @@ entrypoint so the package can be used as a library or via
 ``python -m databusclient``.
 """
 
+__version__ = "0.15"
+
 from databusclient import cli
 from databusclient.api.deploy import create_dataset, create_distribution, deploy
 
-__version__ = "0.15"
 __all__ = ["create_dataset", "deploy", "create_distribution"]
 
 

--- a/databusclient/cli.py
+++ b/databusclient/cli.py
@@ -5,6 +5,7 @@ from typing import List
 
 import click
 
+from databusclient import __version__
 import databusclient.api.deploy as api_deploy
 from databusclient.api.delete import delete as api_delete
 from databusclient.api.download import download as api_download, DownloadAuthError
@@ -12,6 +13,7 @@ from databusclient.extensions import webdav
 
 
 @click.group()
+@click.version_option(version=__version__, prog_name="databusclient")
 def app():
     """Databus Client CLI.
 


### PR DESCRIPTION
Resolves  #72   the requested feature to add a `--version` / `-V` flag.

This exposes the package version via the CLI (e.g., `databusclient --version`). The `__version__` was refactored in `__init__.py` to avoid circular imports when loaded by `cli.py`.