### PR TITLE
feat(download): add overall progress bar for multi-file downloads

### DIFF
--- a/databusclient/api/download.py
+++ b/databusclient/api/download.py
@@ -541,7 +541,10 @@ def _download_files(
         validate_checksum: Whether to validate checksums after downloading.
         checksums: Dictionary mapping URLs to their expected checksums.
     """
-    for url in urls:
+    # Overall progress bar for multiple files
+    # We use position=0 so it stays at the top, while individual file progress 
+    # bars (which are not given a position explicitly) will print below it.
+    for url in tqdm(urls, desc="Overall Progress", unit="file", position=0):
         expected = None
         if checksums and isinstance(checksums, dict):
             expected = checksums.get(url)


### PR DESCRIPTION
Resolves #71  the requested feature for an overall progress bar.

This PR wraps the URL iteration list in `_download_files()` with a `tqdm` progress bar (with `position=0`) to display the overall completion progress across all files, which complements the existing per-file byte-level progress bars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an overall progress indicator for multi-file downloads, making it easier to track total download progress at a glance.
  * Individual file progress display remains available during each download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->