### PR TITLE
fix(api): use SPARQLWrapper.setMethod() for POST requests

### DIFF
--- a/databusclient/api/download.py
+++ b/databusclient/api/download.py
@@ -595,7 +595,7 @@ def _query_sparql_endpoint(endpoint_url, query, databus_key=None) -> dict:
         Dictionary containing the query results.
     """
     sparql = SPARQLWrapper(endpoint_url)
-    sparql.method = "POST"
+    sparql.setMethod("POST")
     sparql.setQuery(query)
     sparql.setReturnFormat(JSON)
     if databus_key is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ if "SPARQLWrapper" not in sys.modules:
         def __init__(self, *args, **kwargs):
             pass
 
+        def setMethod(self, m):
+            self._method = m
+
         def setQuery(self, q):
             self._q = q
 


### PR DESCRIPTION
## Description

The SPARQLWrapper library does not expose  as a settable public attribute. Direct assignment () is silently ignored, causing all SPARQL queries to use GET instead of POST.

This fix uses the correct API: .

## Changes

- Changed  to  in 

## Testing

- Verified that SPARQLWrapper documentation recommends using  API
- The fix ensures large SPARQL queries (e.g., from collection endpoints) are sent via POST, avoiding URL length limits

Fixes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPARQL endpoint requests by correctly applying the POST method, ensuring queries execute reliably.
* **Tests**
  * Updated the lightweight SPARQL wrapper test double to support setting the request method, improving compatibility with the updated request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->