### PR TITLE
fix: enforce abstract length limit (<= 200 chars) and validate Databus URIs

### DIFF
--- a/databusclient/api/deploy.py
+++ b/databusclient/api/deploy.py
@@ -12,6 +12,8 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import requests
 
+from databusclient.api.utils import validate_databus_version_uri
+
 _debug = False
 
 
@@ -352,13 +354,19 @@ def create_dataset(
         OPTIONAL! Metadata for the Group: Description. NOTE: Is only used if all group metadata is set
     """
 
+    if len(artifact_version_abstract.strip()) > 200:
+        raise BadArgumentException(
+            f"Artifact & version abstract exceeds maximum allowed length of 200 characters "
+            f"(got {len(artifact_version_abstract.strip())})."
+        )
+
+    try:
+        validate_databus_version_uri(version_id)
+    except ValueError as e:
+        raise BadArgumentException(str(e)) from e
+
     _versionId = str(version_id).strip("/")
     parts = _versionId.rsplit("/", 4)
-    if len(parts) < 5:
-        raise BadArgumentException(
-            f"Invalid version_id format: '{version_id}'. "
-            f"Expected format: <BASE>/<ACCOUNT>/<GROUP>/<ARTIFACT>/<VERSION>"
-        )
     _, _account_name, _group_name, _artifact_name, version = parts
 
     # could be build from stuff above,

--- a/databusclient/api/utils.py
+++ b/databusclient/api/utils.py
@@ -71,3 +71,29 @@ def compute_sha256_and_length(filepath):
             sha256.update(chunk)
             total_length += len(chunk)
     return sha256.hexdigest(), total_length
+
+
+def validate_databus_version_uri(uri: str) -> None:
+    """Validate a Databus version URI format.
+
+    Expects format: http(s)://<HOST>/<ACCOUNT>/<GROUP>/<ARTIFACT>/<VERSION>
+
+    Raises:
+        ValueError: If URI scheme, host, or path segments are invalid or missing.
+    """
+    if not uri or not isinstance(uri, str):
+        raise ValueError("Databus version_id must be a non-empty string.")
+
+    if not (uri.startswith("http://") or uri.startswith("https://")):
+        raise ValueError(
+            f"Invalid version_id URI scheme: '{uri}'. Must start with 'http://' or 'https://'."
+        )
+
+    stripped_uri = uri.removeprefix("https://").removeprefix("http://").strip("/")
+    parts = stripped_uri.split("/")
+
+    if len(parts) != 5 or any(not part or part.strip() == "" for part in parts):
+        raise ValueError(
+            f"Invalid version_id format: '{uri}'. Expected format: <BASE>/<ACCOUNT>/<GROUP>/<ARTIFACT>/<VERSION>"
+        )
+

--- a/databusclient/api/utils.py
+++ b/databusclient/api/utils.py
@@ -4,9 +4,17 @@ Contains small parsing helpers and HTTP helpers that are shared by
 `download`, `deploy` and `delete` modules.
 """
 
-from typing import Optional, Tuple
 import hashlib
+import re
+from typing import Optional, Tuple
+from urllib.parse import urlparse
 import requests
+
+# Regex for Databus identifier components (account, group, artifact, version)
+_DATABUS_ID_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
+# Regex for authority (host:port)
+_DATABUS_AUTHORITY_RE = re.compile(r"^[a-zA-Z0-9.-]+(?::[0-9]+)?$")
+
 
 
 def get_databus_id_parts_from_file_url(
@@ -76,10 +84,10 @@ def compute_sha256_and_length(filepath):
 def validate_databus_version_uri(uri: str) -> None:
     """Validate a Databus version URI format.
 
-    Expects format: http(s)://<HOST>/<ACCOUNT>/<GROUP>/<ARTIFACT>/<VERSION>
+    Expects format: http(s)://<AUTHORITY>/<ACCOUNT>/<GROUP>/<ARTIFACT>/<VERSION>
 
     Raises:
-        ValueError: If URI scheme, host, or path segments are invalid or missing.
+        ValueError: If URI scheme, authority, trailing slashes, or path components are invalid.
     """
     if not uri or not isinstance(uri, str):
         raise ValueError("Databus version_id must be a non-empty string.")
@@ -89,11 +97,27 @@ def validate_databus_version_uri(uri: str) -> None:
             f"Invalid version_id URI scheme: '{uri}'. Must start with 'http://' or 'https://'."
         )
 
-    stripped_uri = uri.removeprefix("https://").removeprefix("http://").strip("/")
-    parts = stripped_uri.split("/")
+    parsed = urlparse(uri)
+    if not parsed.netloc or not _DATABUS_AUTHORITY_RE.match(parsed.netloc):
+        raise ValueError(
+            f"Invalid authority in version_id URI: '{parsed.netloc or uri}'."
+        )
 
-    if len(parts) != 5 or any(not part or part.strip() == "" for part in parts):
+    # Preserve slash delimiters: path must start with '/' followed by account/group/artifact/version
+    # Any trailing slash, double slash, or extra segment creates empty or extra parts.
+    path_segments = parsed.path.split("/")[1:]
+
+    if len(path_segments) != 4:
         raise ValueError(
             f"Invalid version_id format: '{uri}'. Expected format: <BASE>/<ACCOUNT>/<GROUP>/<ARTIFACT>/<VERSION>"
         )
+
+    component_names = ["ACCOUNT", "GROUP", "ARTIFACT", "VERSION"]
+    for name, seg in zip(component_names, path_segments):
+        if not seg or not _DATABUS_ID_RE.match(seg):
+            raise ValueError(
+                f"Invalid Databus {name} component '{seg}' in version_id: '{uri}'. "
+                "Must be non-empty and contain only alphanumeric characters, underscores, hyphens, or dots."
+            )
+
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -128,3 +128,35 @@ def test_empty_cvs():
     }
 
     assert dataset == correct_dataset
+
+
+def test_abstract_length_validation():
+    long_abstract = "a" * 205
+    with pytest.raises(BadArgumentException, match="exceeds maximum allowed length of 200 characters"):
+        create_dataset(
+            version_id="https://databus.dbpedia.org/user/group/artifact/1.0.0",
+            artifact_version_title="Test Title",
+            artifact_version_abstract=long_abstract,
+            artifact_version_description="Test description",
+            license_url="https://dalicc.net/licenses/cc-by-4.0",
+            distributions=[],
+        )
+
+
+def test_version_id_uri_validation():
+    invalid_uris = [
+        "databus.dbpedia.org/user/group/artifact/1.0.0",  # missing scheme
+        "https://databus.dbpedia.org/user/group/artifact",  # missing version part
+        "https://databus.dbpedia.org/user//artifact/1.0.0",  # empty group part
+    ]
+    for invalid_uri in invalid_uris:
+        with pytest.raises(BadArgumentException):
+            create_dataset(
+                version_id=invalid_uri,
+                artifact_version_title="Test Title",
+                artifact_version_abstract="Valid abstract",
+                artifact_version_description="Test description",
+                license_url="https://dalicc.net/licenses/cc-by-4.0",
+                distributions=[],
+            )
+

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -148,6 +148,8 @@ def test_version_id_uri_validation():
         "databus.dbpedia.org/user/group/artifact/1.0.0",  # missing scheme
         "https://databus.dbpedia.org/user/group/artifact",  # missing version part
         "https://databus.dbpedia.org/user//artifact/1.0.0",  # empty group part
+        "https://databus.dbpedia.org/user/group/artifact/1.0.0/",  # trailing slash
+        "https://databus.dbpedia.org/user/gr oup/artifact/1.0.0",  # component containing space
     ]
     for invalid_uri in invalid_uris:
         with pytest.raises(BadArgumentException):
@@ -159,4 +161,5 @@ def test_version_id_uri_validation():
                 license_url="https://dalicc.net/licenses/cc-by-4.0",
                 distributions=[],
             )
+
 


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes input validation gaps when creating Databus dataset metadata:
1. **Abstract Length Validation**: Enforces the documented maximum limit of 200 characters for `artifact_version_abstract` in `create_dataset()`, raising `BadArgumentException` when exceeded.
2. **Databus URI Validation**: Implemented `validate_databus_version_uri()` helper in `databusclient/api/utils.py` to ensure version URIs have valid HTTP/HTTPS schemes and valid path components (`<BASE>/<ACCOUNT>/<GROUP>/<ARTIFACT>/<VERSION>`).
3. **Unit Tests**: Added comprehensive test cases in `tests/test_deploy.py` for abstract length limit enforcement and invalid URI formats.

**Related Issues**
Fixes #89 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update
- [ ] Housekeeping

## Checklist:
- [x] My code follows the ruff code style of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
    - [x] `poetry run pytest` - all tests passed
    - [x] `poetry run ruff check` - no linting errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset creation validation for abstracts exceeding 200 characters.
  * Added validation for version identifiers, including required URL schemes and complete URI segments.
  * Invalid inputs now return clearer argument errors.

* **Tests**
  * Added coverage for abstract length limits and invalid version identifier formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->